### PR TITLE
github_annotation: Fix the github action path on windows

### DIFF
--- a/cargo-annotation/action.yml
+++ b/cargo-annotation/action.yml
@@ -23,7 +23,7 @@ runs:
           CMD="$CMD --message-format=json"
         fi
 
-        eval "$CMD | ${{ github.action_path }}/annotation.sh"
+        eval "$CMD | $GITHUB_ACTION_PATH/annotation.sh"
       shell: bash
       env:
         WITH_ANNOTATION: ${{ inputs.with-annotation }}


### PR DESCRIPTION
This will fix Github.action_path contains `\` on windows runners 

https://github.com/orgs/community/discussions/25910